### PR TITLE
Add missing Grantlee5 library to fix missing grantlee/safestring.h error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 find_package(Qt5 COMPONENTS Core Network Sql Gui REQUIRED)
 find_package(Cutelyst2Qt5 2.0.0 REQUIRED)
 find_package(KF5SyntaxHighlighting REQUIRED)
+find_package(Grantlee5 REQUIRED)
 
 # Auto generate moc files
 set(CMAKE_AUTOMOC ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,9 +17,9 @@ target_link_libraries(Pastelyst
     Cutelyst::Utils::Pagination
     Cutelyst::Authentication
     Cutelyst::Session
+    Grantlee5::Templates
     Qt5::Core
     Qt5::Network
     Qt5::Sql
     Qt5::Gui
 )
-


### PR DESCRIPTION
> root.cpp:28:10: ölümcül hata: grantlee/safestring.h: No such file or directory
>  #include <grantlee/safestring.h>
>           ^~~~~~~~~~~~~~~~~~~~~~~
> derleme sonlandırıldı.

I get this error while build pastelyst on Fedora 29. Changes may fix this. Worked for me.