### PR TITLE
make password field disabled default to prevent misleading of autofill

### DIFF
--- a/root/src/index.html
+++ b/root/src/index.html
@@ -31,14 +31,14 @@
           <div class="input-group-prepend">
             <div class="input-group-text">🔒</div>
           </div>
-          <input type="password" class="form-control" name="password" id="password" autofocus placeholder="Password">
+          <input type="password" class="form-control" name="password" id="password" autofocus placeholder="Password" disabled>
         </div>
       </div>
     </div>
 
     <div class="col-3">
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="defaultCheck1" name="private">
+        <input class="form-check-input" type="checkbox" id="defaultCheck1" name="private" onchange="document.getElementById('password').disabled = !this.checked;">
         <label class="form-check-label" for="defaultCheck1">
           Submit privately
         </label>


### PR DESCRIPTION
submit privately checkbox not active in default behavior but sometimes
password field fill by autofill and this misleads the user
although the user thinks that paste is public, the paste is actualy private

const bool priv = params.value(QStringLiteral("private")) == QLatin1String("on") || !password.isEmpty();

these changes can help guide the user better:

- if submit privately not checked and no password: public
- if submit privately checked and no pasword: unlisted
- if submit privately checked and some password: private